### PR TITLE
修复Mac下dock栏不显示图标

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -16,7 +16,7 @@ let mini
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([{ scheme: 'app', privileges: { secure: true, standard: true } }])
 
-function createWindow () {
+function createWindow() {
   win = new BrowserWindow({
     width: 1080,
     height: 720,
@@ -44,7 +44,7 @@ function createWindow () {
   })
 }
 
-function createMini () {
+function createMini() {
   mini = new BrowserWindow({
     width: 550,
     minWidth: 260,
@@ -177,6 +177,9 @@ if (!gotTheLock) {
     createWindow()
   })
 }
+
+// show mac dock icon
+app.dock.show()
 
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {


### PR DESCRIPTION
查询electron文档，发现添加`app.dock.show()`可以显示dock图标
Mac10.15.5下可用
Manjaro KDE下无影响
没有Windows，没测试